### PR TITLE
[새기능]: context Menu 컴포넌트 추가

### DIFF
--- a/src/renderer/src/design/ui/ContextMenu/ContextMenu.tsx
+++ b/src/renderer/src/design/ui/ContextMenu/ContextMenu.tsx
@@ -1,0 +1,63 @@
+import { color } from '@renderer/design/styles'
+import { flex } from '@renderer/utils'
+import { styled } from 'styled-components'
+
+interface Data {
+  label: string
+  value: string
+  onClick: () => void
+}
+
+interface Props {
+  data: Data[]
+}
+
+const ContextMenu = ({ data }: Props) => {
+  return (
+    <StyledContextMenu>
+      {data.map((item) => (
+        <ContextMenuItem
+          key={item.value}
+          onClick={() => {
+            item.onClick()
+          }}
+        >
+          {item.label}
+        </ContextMenuItem>
+      ))}
+    </StyledContextMenu>
+  )
+}
+
+export default ContextMenu
+
+const StyledContextMenu = styled.div`
+  ${flex({ flexDirection: 'column', alignItems: 'flex-start' })}
+  width: 200px;
+  padding: 8px 0px;
+  gap: 4px;
+
+  border-radius: 12px;
+  background: ${color.G0};
+  box-shadow:
+    0px 53px 15px 0px rgba(112, 112, 112, 0),
+    0px 34px 14px 0px rgba(112, 112, 112, 0.01),
+    0px 19px 12px 0px rgba(112, 112, 112, 0.05),
+    0px 9px 9px 0px rgba(112, 112, 112, 0.09),
+    0px 2px 5px 0px rgba(112, 112, 112, 0.1);
+`
+
+const ContextMenuItem = styled.div`
+  ${flex({ alignItems: 'center' })}
+  padding: 10px 16px;
+  gap: 8px;
+  width: 100%;
+
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background 0.2s;
+
+  &:hover {
+    background: ${color.G20};
+  }
+`

--- a/src/renderer/src/hooks/index.ts
+++ b/src/renderer/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useBoolean } from './useBoolean'

--- a/src/renderer/src/hooks/index.ts
+++ b/src/renderer/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useBoolean } from './useBoolean'
+export { default as useOutsideClick } from './useOutsideClick'

--- a/src/renderer/src/hooks/useBoolean.ts
+++ b/src/renderer/src/hooks/useBoolean.ts
@@ -1,0 +1,13 @@
+import { useCallback, useState } from 'react'
+
+const useBoolean = (initialValue?: boolean) => {
+  const [value, setValue] = useState(!!initialValue)
+
+  const setTrue = useCallback(() => setValue(true), [])
+  const setFalse = useCallback(() => setValue(false), [])
+  const toggle = useCallback(() => setValue((prev) => !prev), [])
+
+  return { value, setValue, setTrue, setFalse, toggle }
+}
+
+export default useBoolean

--- a/src/renderer/src/hooks/useOutsideClick.ts
+++ b/src/renderer/src/hooks/useOutsideClick.ts
@@ -1,7 +1,9 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, RefObject } from 'react'
 
-const useOutsideClick = (callback: () => void) => {
-  const ref = useRef<HTMLElement>(null)
+const useOutsideClick = <T extends HTMLElement = HTMLElement>(
+  callback: () => void
+): RefObject<T | null> => {
+  const ref = useRef<T | null>(null)
 
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {

--- a/src/renderer/src/hooks/useOutsideClick.ts
+++ b/src/renderer/src/hooks/useOutsideClick.ts
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react'
+
+const useOutsideClick = (callback: () => void) => {
+  const ref = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        callback()
+      }
+    }
+
+    window.addEventListener('mousedown', handleClick)
+    return () => window.removeEventListener('mousedown', handleClick)
+  }, [callback])
+
+  return ref
+}
+
+export default useOutsideClick


### PR DESCRIPTION
## 🧩 관련 이슈

<!-- 예: #123 -->

- 관련 이슈 번호: #13 

<br>

## ✨ 변경 사항 요약

<!-- 주요 변경 사항을 간단히 설명해주세요 -->
디자인 시스템에 정의된 context Menu 컴포넌트를 추가했습니다.

<br>

## 🔨 구현한 작업 내역

<!-- 어떤 작업을 했는지 명확하게 항목별로 작성해주세요 -->

- useBoolean 커스텀 훅 추가
- useOutsideClick 커스텀 훅 추가
- context Menu 컴포넌트 추가

<br>

## 📸 스크린샷 (옵션)

<!-- UI가 바뀌었거나 주요 변경 사항이 시각적으로 보이는 경우 첨부해주세요 -->

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | ![image](https://github.com/user-attachments/assets/f1013002-8aea-4109-9881-33b0d68f9546)|

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 커스텀 메뉴 항목과 클릭 핸들러를 지원하는 ContextMenu 컴포넌트가 추가되었습니다.
  - 불리언 상태를 간편하게 관리할 수 있는 useBoolean 훅이 추가되었습니다.
  - 지정한 영역 외부 클릭 시 콜백을 실행하는 useOutsideClick 훅이 추가되었습니다.

- **리팩터**
  - useBoolean과 useOutsideClick 훅을 한 곳에서 쉽게 가져올 수 있도록 hooks 인덱스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->